### PR TITLE
fix uninitialized property

### DIFF
--- a/karcher/device.py
+++ b/karcher/device.py
@@ -140,7 +140,7 @@ class DeviceProperties:
 
     def __init__(self, **kwargs):
         setattr(self, 'cur_path', [])
-        setattr(self, 'net_stauts', DevicePropertiesNetwork())
+        setattr(self, 'net_status', DevicePropertiesNetwork())
         setattr(self, 'order_total', DevicePropertiesOrderTotal())
         setattr(self, 'privacy', DevicePropertiesPrivacy())
         setattr(self, 'quiet_status', DevicePropertiesQuiet())


### PR DESCRIPTION
When the robot is idle, parked at the base, and I call `kh.get_device_properties(dev)`, I get back the following backtrace (after removing some asyncio layers due to awaits):
```
   File "/nix/store/asiphbpiy2gmidfm3xbwcikayhs66289-python3-3.11.7/lib/python3.11/dataclasses.py", line 240, in wrapper
     result = user_function(self)
              ^^^^^^^^^^^^^^^^^^^
   File "<string>", line 3, in __repr__
 AttributeError: 'DeviceProperties' object has no attribute 'net_status'. Did you mean: 'net_stauts'?
```
What's particularly funny is that when run as `python -m asyncio`, to get the `await` working in the REPL, the exception does not contain that useful hint, and it looks like the following instead:
```
 >>> kh.get_device_properties(d[0])
 Traceback (most recent call last):
   File "/nix/store/asiphbpiy2gmidfm3xbwcikayhs66289-python3-3.11.7/lib/python3.11/concurrent/futures/_base.py", line 456, in result
     return self.__get_result()
            ^^^^^^^^^^^^^^^^^^^
   File "/nix/store/asiphbpiy2gmidfm3xbwcikayhs66289-python3-3.11.7/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
     raise self._exception
   File "/nix/store/asiphbpiy2gmidfm3xbwcikayhs66289-python3-3.11.7/lib/python3.11/asyncio/__main__.py", line 34, in callback
     coro = func()
            ^^^^^^
   File "<console>", line 1, in <module>
   File "/nix/store/asiphbpiy2gmidfm3xbwcikayhs66289-python3-3.11.7/lib/python3.11/dataclasses.py", line 240, in wrapper
     result = user_function(self)
              ^^^^^^^^^^^^^^^^^^^
   File "<string>", line 3, in __repr__
 AttributeError: 'DeviceProperties' object has no attribute 'net_status'
```
Anyway, the root cause was just a typo in `DeviceProperties.__init__`.

Fixes: e0065b6