### PR TITLE
setup: we are not compatible with  paho-mqtt >= 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ aiohttp >= 3.8
 protobuf >= 4.22
 click >= 8.1
 cryptography >= 40.0
-paho-mqtt >= 1.6
+paho-mqtt >= 1.6, < 2

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     install_requires=[
         'click',
         'aiohttp',
-        'paho-mqtt',
+        'paho-mqtt<2',
         'cryptography',
         'protobuf'
     ],


### PR DESCRIPTION
Yesterday they [made a stable v2.0.0 release](https://github.com/eclipse/paho.mqtt.python/releases/tag/v2.0.0) with multiple breaking changes, and that just broke my fresh `venv`. I'd prefer to defer the decision on whether to port to paho-mqtt v2.0 or not to the original maintainer, so let's add a pin in the meanwhile.

Also, the setup.py's install_requires vs. requirements.txt difference looks a bit silly to me, but I unfortunately recognize that [this is the recommended practice](https://stackoverflow.com/questions/14399534/reference-requirements-txt-for-the-install-requires-kwarg-in-setuptools-setup-py) by Python's own packagings docs.